### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's easy to get started, first include the JavaScript files and the CSS
 <script type="text/javascript" src="js/so_tag.js"></script>
 ```
 
-And then assign sotag(). You'll notice the default tags are written like this: <em>24_tagname</em>, this is becasue the tags are stored in the database and the first number is relative to the ID of that tag.
+And then assign sotag(). You'll notice the default tags are written like this: <em>24_tagname</em>, this is because the tags are stored in the database and the first number is relative to the ID of that tag.
 
 ```html
 <input type="text" value="1_some, 2_example, 3_tags" id="basic_example" />


### PR DESCRIPTION
@AdamTester, I've corrected a typographical error in the documentation of the [SOTag](https://github.com/AdamTester/SOTag) project. Specifically, I've changed becasue to because. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
